### PR TITLE
Fix md-data-table-cell width preservation after header cell resize

### DIFF
--- a/src/md-data-table-cell.ts
+++ b/src/md-data-table-cell.ts
@@ -11,9 +11,14 @@ export class MdDataTableCell extends LitElement {
 		}
 	`;
 
+	@property({type: String})
+	width: string = '';
+
 	render() {
 		return html`
-            <slot></slot>
+            <div style="width: ${this.width};">
+                <slot></slot>
+            </div>
         `;
 	}
 }

--- a/src/md-data-table-header-cell.ts
+++ b/src/md-data-table-header-cell.ts
@@ -42,7 +42,13 @@ export class MdDataTableHeaderCell extends LitElement {
 
 	private _onMouseMove = (event: MouseEvent) => {
 		const dx = event.clientX - this._startX;
-		this.style.width = `${this._startWidth + dx}px`;
+		const newWidth = this._startWidth + dx;
+		this.style.width = `${newWidth}px`;
+		this.dispatchEvent(new CustomEvent('column-resize', {
+			detail: { column: this.column, width: newWidth },
+			bubbles: true,
+			composed: true
+		}));
 	};
 
 	private _onMouseUp = () => {

--- a/src/md-data-table.ts
+++ b/src/md-data-table.ts
@@ -130,28 +130,19 @@ export class MdDataTable extends LitElement {
 		this._loadMoreData(0, 50, this._sortColumn, this._sortDirection);
 	}
 
-	private _handleResize(event: MouseEvent, columnIndex: number) {
-		const startX = event.clientX;
-		const startWidth = this.shadowRoot!.querySelectorAll('.header-row md-data-table-header-cell')[columnIndex].offsetWidth;
+	private _handleResize(event: CustomEvent) {
+		const { column, width } = event.detail;
+		const columnIndex = this.columns.indexOf(column);
 
-		const onMouseMove = (moveEvent: MouseEvent) => {
-			const dx = moveEvent.clientX - startX;
-			const newWidth = startWidth + dx;
-			this.shadowRoot!.querySelectorAll('.header-row md-data-table-header-cell')[columnIndex].style.width = `${newWidth}px`;
+		if (columnIndex !== -1) {
+			this.shadowRoot!.querySelectorAll('.header-row md-data-table-header-cell')[columnIndex].style.width = `${width}px`;
 			this.shadowRoot!.querySelectorAll('.table md-data-table-cell').forEach((cell, index) => {
 				if (index % this.columns.length === columnIndex) {
-					(cell as HTMLElement).style.width = `${newWidth}px`;
+					(cell as HTMLElement).style.width = `${width}px`;
+					(cell as any).width = `${width}px`; // P1e14
 				}
 			});
-		};
-
-		const onMouseUp = () => {
-			document.removeEventListener('mousemove', onMouseMove);
-			document.removeEventListener('mouseup', onMouseUp);
-		};
-
-		document.addEventListener('mousemove', onMouseMove);
-		document.addEventListener('mouseup', onMouseUp);
+		}
 	}
 
 	render() {
@@ -162,7 +153,7 @@ export class MdDataTable extends LitElement {
 						${this.columns.map((column, index) => html`
 							<md-data-table-header-cell
 									@click=${() => this._handleSort(column)}
-									@mousedown=${(event: MouseEvent) => this._handleResize(event, index)}
+									@column-resize=${this._handleResize}
 									.sortDirection=${this._sortColumn === column ? this._sortDirection : null}
 							>
 								${column}


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MarekBednar1972/material-datatable/pull/2?shareId=152b4188-3317-48cf-93df-76f32726c925).